### PR TITLE
Remove Unused Colors from VS-Dark-color-theme.json

### DIFF
--- a/themes/VS-Dark-color-theme.json
+++ b/themes/VS-Dark-color-theme.json
@@ -42,12 +42,6 @@
       "settings": {
         "foreground": "#F44747"
       }
-    },
-    {
-      "scope": "token.debug-token",
-      "settings": {
-        "foreground": "#B267E6"
-      }
     }
   ]
 }


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)

I removed these colors from VS-Dark-color-theme.json because they're not really used. It's not on the critical path for these token colors to exist.

## Test plan

1. Download VS Code
2. Go to ~/.vscode/extensions
3. Git clone `git clone https://github.com/ryanolsonx/vscode-distilled-theme`
4. Switch theme to "Visual Studio Dark (No Syntax Highlighting)" and validate that things show as before (see image below)

<img width="1103" alt="Screenshot 2024-06-13 at 2 39 38 PM" src="https://github.com/ryanolsonx/vscode-distilled-theme/assets/238929/71dec6b7-d0f2-434f-a3df-ab0aba56608f">

## Before asking for code review

- I have filled out the "Brief context on code" and "Test plan" sections above
- I have verified test plan written above works
- I have attached screenshots for any new UI changes, or there are no new UI changes
- I have asked for a review from a Designer, or there are no new UI changes to review
- I have done my own CR and resolved all issues that I found
